### PR TITLE
fix build error on windows

### DIFF
--- a/build.dart
+++ b/build.dart
@@ -33,7 +33,7 @@ Future<void> _builder(BuildConfig buildConfig, BuildOutput buildOutput) async {
   _checkCmd('make');
   final pkgRoot = buildConfig.packageRoot;
 
-  final buildDir = p.join('src', 'build');
+  final buildDir = p.join(p.fromUri(pkgRoot), 'src', 'build');
   final dir = Directory(buildDir);
   if (!dir.existsSync()) {
     dir.createSync(recursive: true);

--- a/build.dart
+++ b/build.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io' show Directory, File, Process, exit, stderr, stdout;
+import 'dart:io' show Directory, File, Process, Platform, exit, stderr, stdout;
 import 'package:glob/glob.dart' show Glob;
 import 'package:glob/list_local_fs.dart';
 import 'package:path/path.dart' as p;
@@ -19,8 +19,8 @@ void main(List<String> args) async {
 
 Future<void> _checkCmd(String cmd) async {
   final proc = await Process.start(
-    'which',
-    [cmd],
+    Platform.isWindows ? 'powershell' : 'which',
+    Platform.isWindows ? ['/c', 'Get-Command', cmd] : [cmd],
   );
   final code = await proc.exitCode;
   if (code != 0) {


### PR DESCRIPTION
1. 在windows平台上不使用 where 命令，使用 powershell 的 Get-Command。这将修复windows上的构建问题。
2. buildDir 使用绝对路径而不是相对路径，这将允许从引用了 opencc 包的工程目录运行 `dart --enable-experiment=native-assets run opencc` 进行构建